### PR TITLE
Add support for Django 5.2

### DIFF
--- a/djmoney/admin.py
+++ b/djmoney/admin.py
@@ -11,10 +11,10 @@ MODULES_TO_PATCH = [admin_utils, admin_helpers, admin_list]
 def setup_admin_integration():
     original_display_for_field = admin_utils.display_for_field
 
-    def display_for_field(value, field, empty):
+    def display_for_field(value, field, empty, avoid_link=False):
         if isinstance(field, MoneyField):
             return str(value)
-        return original_display_for_field(value, field, empty)
+        return original_display_for_field(value, field, empty, avoid_link=False)
 
     for mod in MODULES_TO_PATCH:
         setattr(mod, "display_for_field", display_for_field)


### PR DESCRIPTION
Due to django-money monkey patching here, the upgrade to Django 5.2 breaks the admin page as it adds an extra arg.

I've added the extra arg to make it compatible.